### PR TITLE
Implement static sharding for shift service

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(kotlin("test"))

--- a/client/src/main/kotlin/com/harbourspace/client/shifts/ShiftProcessingService.kt
+++ b/client/src/main/kotlin/com/harbourspace/client/shifts/ShiftProcessingService.kt
@@ -60,7 +60,7 @@ class ShiftProcessingService(
             val batch = shift.batch
             val remaining = shiftRequestRepository.findByStatus(ProcessingStatus.PENDING)
                 .count { it.batch.id == batch.id }
-            if (remaining == 0L) {
+            if (remaining == 0) {
                 batch.status = ProcessingStatus.COMPLETED
                 batchRequestRepository.save(batch)
             }

--- a/client/src/test/resources/application.properties
+++ b/client/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardContext.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardContext.kt
@@ -1,0 +1,15 @@
+package com.harbourspace.shiftbookingserver.sharding
+
+object ShardContext {
+    private val context = ThreadLocal<Int>()
+
+    fun setShard(shard: Int) {
+        context.set(shard)
+    }
+
+    fun getShard(): Int? = context.get()
+
+    fun clear() {
+        context.remove()
+    }
+}

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardInitializer.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardInitializer.kt
@@ -1,0 +1,21 @@
+package com.harbourspace.shiftbookingserver.sharding
+
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator
+import javax.sql.DataSource
+
+@Configuration
+class ShardInitializer {
+
+    @Bean
+    fun initializeShards(dataSource: DataSource): ApplicationRunner = ApplicationRunner {
+        val routing = dataSource as ShardRoutingDataSource
+        val populator = ResourceDatabasePopulator(ClassPathResource("schema.sql"))
+        routing.shards.forEach { (_, ds) ->
+            populator.execute(ds)
+        }
+    }
+}

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardRoutingDataSource.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardRoutingDataSource.kt
@@ -1,0 +1,20 @@
+package com.harbourspace.shiftbookingserver.sharding
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource
+import javax.sql.DataSource
+
+class ShardRoutingDataSource : AbstractRoutingDataSource() {
+
+    val shards: MutableMap<Any, DataSource> = HashMap()
+
+    override fun determineCurrentLookupKey(): Any? {
+        return ShardContext.getShard()
+    }
+
+    fun initTargets(targets: Map<Any, DataSource>, defaultKey: Any) {
+        this.setTargetDataSources(targets)
+        this.setDefaultTargetDataSource(targets[defaultKey]!!)
+        this.afterPropertiesSet()
+        shards.putAll(targets)
+    }
+}

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardingConfig.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/sharding/ShardingConfig.kt
@@ -1,0 +1,29 @@
+package com.harbourspace.shiftbookingserver.sharding
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import javax.sql.DataSource
+
+@Configuration
+class ShardingConfig {
+    @Value("\${sharding.shards:2}")
+    private var shardCount: Int = 2
+
+    @Bean
+    fun dataSource(): DataSource {
+        val routing = ShardRoutingDataSource()
+        val targetDataSources = HashMap<Any, javax.sql.DataSource>()
+        for (i in 0 until shardCount) {
+            val ds = DataSourceBuilder.create().url("jdbc:h2:mem:shard${'$'}i;DB_CLOSE_DELAY=-1").driverClassName("org.h2.Driver").username("sa").password("").build()
+            targetDataSources[i] = ds
+        }
+        routing.initTargets(targetDataSources, 0)
+        return routing
+    }
+
+    @Bean
+    fun jdbcTemplate(dataSource: DataSource) = JdbcTemplate(dataSource)
+}

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftController.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftController.kt
@@ -2,12 +2,13 @@ package com.harbourspace.shiftbookingserver.shifts
 
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class ShiftController(val repository: ShiftRepository) {
+class ShiftController(private val service: ShiftService) {
 
     @FailureSimulator
     @PostMapping("/shifts")
@@ -20,7 +21,7 @@ class ShiftController(val repository: ShiftRepository) {
             endTime = shiftVm.endTime
         )
         when (shiftVm.action) {
-            "add" -> repository.save(shift)
+            "add" -> service.save(shift)
         }
 
         return "{\"status\": \"ok\"}"
@@ -28,7 +29,7 @@ class ShiftController(val repository: ShiftRepository) {
 
     @GetMapping("/shifts")
     fun getShifts(): ShiftsViewVm {
-        val shifts = repository.findAll().map { shift ->
+        val shifts = service.findAll().map { shift ->
             ShiftViewVm(
                 shiftId = shift.id,
                 companyId = shift.companyId,
@@ -41,14 +42,9 @@ class ShiftController(val repository: ShiftRepository) {
     }
 
     @DeleteMapping("/shifts/{shiftId}")
-    fun deleteShift(@RequestBody shiftId: Long): String {
-        val shift = repository.findById(shiftId)
-        if (shift.isPresent) {
-            repository.delete(shift.get())
-            return "{status: 'ok'}"
-        } else {
-            throw IllegalStateException("Shift not found")
-        }
+    fun deleteShift(@PathVariable shiftId: Long, @RequestBody companyId: String): String {
+        service.deleteById(shiftId, companyId)
+        return "{status: 'ok'}"
     }
 }
 

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftRepository.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftRepository.kt
@@ -3,3 +3,4 @@ package com.harbourspace.shiftbookingserver.shifts
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ShiftRepository : JpaRepository<Shift, Long>
+

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftService.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/shifts/ShiftService.kt
@@ -1,0 +1,46 @@
+package com.harbourspace.shiftbookingserver.shifts
+
+import com.harbourspace.shiftbookingserver.sharding.ShardContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import kotlin.math.abs
+
+@Service
+class ShiftService(private val repository: ShiftRepository,
+                   @Value("\${sharding.shards:2}") private val shardCount: Int) {
+
+    private fun shardForCompany(companyId: String): Int = abs(companyId.hashCode()) % shardCount
+
+    fun save(shift: Shift): Shift {
+        val shard = shardForCompany(shift.companyId)
+        ShardContext.setShard(shard)
+        try {
+            return repository.save(shift)
+        } finally {
+            ShardContext.clear()
+        }
+    }
+
+    fun findAll(): List<Shift> {
+        val result = mutableListOf<Shift>()
+        for (i in 0 until shardCount) {
+            ShardContext.setShard(i)
+            try {
+                result += repository.findAll()
+            } finally {
+                ShardContext.clear()
+            }
+        }
+        return result
+    }
+
+    fun deleteById(id: Long, companyId: String) {
+        val shard = shardForCompany(companyId)
+        ShardContext.setShard(shard)
+        try {
+            repository.deleteById(id)
+        } finally {
+            ShardContext.clear()
+        }
+    }
+}

--- a/shiftbooking-server/src/main/resources/application.properties
+++ b/shiftbooking-server/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=shiftbooking-server
+spring.jpa.hibernate.ddl-auto=update
+sharding.shards=2
+

--- a/shiftbooking-server/src/main/resources/schema.sql
+++ b/shiftbooking-server/src/main/resources/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shifts (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    company_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    start_time VARCHAR(255) NOT NULL,
+    end_time VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## Summary
- enable database sharding for the shiftbooking server
- route datasource connections via a custom routing data source
- initialize schema on all shards
- delegate persistence through new ShiftService
- fix client build and tests to use H2

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6862d6dbfc50832082e8db87c7895f07